### PR TITLE
Svg fo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN apk add --no-cache --virtual .build-deps \
 
 FROM openjdk:8-jre-alpine
 COPY --from=packager /usr/local/eXist /usr/local/eXist
+RUN apk update
+RUN apk add ttf-dejavu
 
 ENV LANG C.UTF-8
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(T)/eXist.expect: $(T)/wget-eXist.log
 	@echo "## $(notdir $@) ##"
 	@echo 'TASK: creating expect file'
 	@echo '#!$(shell which expect) -f' > $(@)
-	echo 'spawn java -jar $(T)/$(shell cat tmp/eXist-latest.version) -console' >> $(@)
+	@echo 'spawn java -jar $(T)/$(shell cat tmp/eXist-latest.version) -console' >> $(@)
 	@echo 'expect "Select target path" { send "$(EXIST_HOME)\n" }'  >> $(@)
 	@echo 'expect "*ress 1" { send "1\n" }'  >> $(@)
 	@echo 'expect "Set Data Directory" { send "$(EXIST_DATA_DIR)\n" }' >> $(@)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Built from openjdk:8-jre-alpine image [![](https://images.microbadger.com/badges
 Pre-build images are available on [dockerhub](https://hub.docker.com/r/grantmacken/alpine-exist/)
 
 The latest build will always be the latest eXist release.
-Earlier versions may be avaiable.
+Earlier versions may be available.
 
 You can simply download them and run the image as usual, e.g.:
 
@@ -48,9 +48,9 @@ The eXist dba user is the default `admin`.
 
 There is no password so change it ASAP
 
-You may do this via the eXist 
+You may do this via the eXist
 [usermanager](http://localhost:8080/exist/apps/usermanager/index.html)
- or see section 'Talking To eXist' below 
+ or see section 'Talking To eXist' below
 
 ### Starting Stopping eXist
 
@@ -65,11 +65,11 @@ docker stop ex
 ### Docker run time environment
 
 The docker-compose run time environment includes
-1. A container name 'ex'. 
+1. A container name 'ex'.
 2. A persistent docker volume named 'data' so the
 important stuff in `${EXIST_HOME}/${EXIST_DATA_DIR}`
 hangs around.
-3. A network named 'www'. 
+3. A network named 'www'.
 4. A port published on 8080
 
 #### If docker-compose is not available
@@ -89,10 +89,10 @@ docker run \
   grantmacken/alpine-exist:latest'
 ```
 
-### Using a Containerised Reverse Proxy 
+### Using a Containerised Reverse Proxy
 
 Be aware when using a reverse proxy in another container,
-don't use 'localhost', use 'ex' ( our named container ) instead, 
+don't use 'localhost', use 'ex' ( our named container ) instead,
 and make sure it belongs to the same named docker 'www' network.
 
 ```
@@ -103,14 +103,14 @@ location @proxy {
 }
 ```
 
-## Docker Image Environment 
+## Docker Image Environment
 
 1. in $PATH the *java* exec is available
 2. the following ENV vars
     * JAVA_HOME
     * EXIST_HOME
     * JAVA_ALPINE_VERSION
-3.  the working directory is located in root directory of the eXist installation. 
+3.  the working directory is located in root directory of the eXist installation.
 
 ## Talking To eXist
 
@@ -125,7 +125,7 @@ docker exec ex ls -al .
 # get eXist version
 docker exec ex java -jar start.jar client -q -u admin -P admin -x \
  'system:get-version()' | tail -1 ; echo
-# list installed repos 
+# list installed repos
 docker exec ex java -jar start.jar client -q -u admin -P admin -x \
  'string-join(repo:list(), "&#10;")' ;  echo
 # change the admin pass to 'nimda'
@@ -165,4 +165,3 @@ To modify -Xmx and CACHE_MEMORY configurations for your exist instance, change `
 cd alpine-eXist
 docker build .
 ```
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   exist:
-    image: grantmacken/alpine-exist:latest
+    image: ${DOCKER_IMAGE}:latest
     container_name: ex
     ports:
         - 8080:8080


### PR DESCRIPTION
using [extension.fo](http://svn.apache.org/repos/asf/xmlgraphics/fop/tags/fop-2_2/fop/examples/fo/basic/extensive.fo) with the following query:
```xml
xquery version "3.1";

let $fo := doc('extensive.fo')
let $param := ()

return
    xmldb:store('fop-test', 'extensive.pdf', xslfo:render($fo, 'application/pdf', $param))
```
Does not produce the correct result (the embedded SVG is missing). Adding ttf-dejavu fixes this, but increases the image size slightly. 